### PR TITLE
Prompt now reflects response is case-sensitive

### DIFF
--- a/Exploratory_Data_Analysis/Exploratory_Graphs/lesson
+++ b/Exploratory_Data_Analysis/Exploratory_Graphs/lesson
@@ -360,7 +360,7 @@
   Figure: goodPlot3.R
 
 - Class: cmd_question
-  Output:  As before, use the up arrow key and change the 3 "west" strings to "east". 
+  Output:  As before, use the up arrow key and change the 3 "West" strings to "East". 
   CorrectAnswer: plot(east$latitude, east$pm25, main = "East")
   AnswerTests: omnitest(correctExpr='plot(east$latitude, east$pm25, main = "East")')
   Hint: Type  plot(east$latitude, east$pm25, main = "East") at the command prompt.


### PR DESCRIPTION
In line 363, the prompt -**_Output_** in the swirl code- instructed the student to change the string "west" to "east".
**_CorrectAnswer_**, however, requires the string be in proper case to mark it as correct. (I know because I acted on what the prompt said and it was marked wrong. :-)
**_Output_** was modified to now show "East" and "West" in proper case.